### PR TITLE
Creating a new directory or file no longer have zero permissions.

### DIFF
--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -105,7 +105,7 @@ static int createUnixDirectory(char *absolutePath, int forceCreate) {
   }
 
   status = directoryMake(absolutePath,
-                         0,
+                         0700,
                          &returnCode,
                          &reasonCode);
 
@@ -506,7 +506,7 @@ static int writeEmptyUnixFile(char *absolutePath, int forceWrite) {
   setUmask(DEFAULT_UMASK);
   UnixFile *dest = fileOpen(absolutePath,
                             FILE_OPTION_CREATE | FILE_OPTION_TRUNCATE | FILE_OPTION_WRITE_ONLY,
-                            0,
+                            0700,
                             0,
                             &returnCode,
                             &reasonCode);


### PR DESCRIPTION
Previously, the default permissions were not set correctly. They should not correctly be set to read, write, and execute for the file owner.